### PR TITLE
Bump golangci-lint to avoid missing asciicheck dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.13
 require (
 	github.com/dgottlieb/smarty-assertions v1.2.6
 	github.com/edaniels/golinters v0.0.4
-	github.com/golangci/golangci-lint v1.39.0
+	github.com/golangci/golangci-lint/v2 v2.5.0
 	github.com/google/go-cmp v0.5.4
 	google.golang.org/protobuf v1.25.0
 )

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -5,5 +5,5 @@ package tools
 
 import (
 	_ "github.com/edaniels/golinters/cmd/combined"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 )


### PR DESCRIPTION
The prior version of golangci-lint attempted to pull in a go module dependency that no longer exists on the Internet.

If you start from an empty go module cache, `go mod tidy` would fail for any Viam module that pulls in `go.viam.com/test`

The newer golangci-lint did a hard fork of the missing asciicheck repo.